### PR TITLE
Add discussion of user questions

### DIFF
--- a/docs/plan/index.md
+++ b/docs/plan/index.md
@@ -297,6 +297,8 @@ additional, indirect benefits:
   questions would have to be answered before any such thing can be accomplished;
   including, for example, the question of “interop profiles”.)
 
+* The testing framework could answer user questions about how the Fediverse behaves.  The behaviour of both individual apps and the Fediverse more widely is complicated and contradicts the experience of typical users on commercial applications.  This leads to questions, which currently tend to be answered with guesses and speculation.  This testing framework would allow those questions to be answered experimentally, definitively, taking some friction out of online discussions.
+
 ## Tester experience (straw proposal)
 
 To illustrate how a tester might interact with the test suite, consider the following.


### PR DESCRIPTION
I'm currently wasting _vast_ amounts of time building my own custom set of docker images just to answer my own questions about how Fediverse apps behave.  I'm not even really a developer of Fediverse applications.  So that's what I would like to see.

What I want to achieve is something like the screenshots [here](https://mat.exon.name/notablog/wordpress-activitypub/).  That's a different focus to automated testing, which isn't trying to be especially realistic, or construct a narrative.  So that might be out of scope.  But it would be nice if that worked.