### PR TITLE
Add built-in noopN tests -- makes debugging node provisioning easier

### DIFF
--- a/src/feditest/__init__.py
+++ b/src/feditest/__init__.py
@@ -112,6 +112,18 @@ def _load_tests_pass2() -> None:
               + '\n    '.join( _registered_as_test_step.keys() ))
 
 
+def load_default_tests() -> None:
+    """
+    Load built-in tests. These don't really test anything, but are convenient when building feditest.
+    """
+    global all_tests
+
+    all_tests['noop2'] = TestFromTestFunction('noop2', 'This denegerate 2-node test does nothing', lambda node1, node2: None )
+    all_tests['noop3'] = TestFromTestFunction('noop3', 'This denegerate 3-node test does nothing', lambda node1, node2, node3: None )
+    all_tests['noop4'] = TestFromTestFunction('noop4', 'This denegerate 4-node test does nothing', lambda node1, node2, node3, node4: None )
+    # Do not replace those lambda parameters with _: we need to look up their names for role mapping
+
+
 def test(to_register: type[Any]) -> type[Any]:
     """
     Use as a decorator to register a supposed test. Use either on a function (running of which constitutes the entire test)

--- a/src/feditest/cli/commands/create_session_template.py
+++ b/src/feditest/cli/commands/create_session_template.py
@@ -22,6 +22,7 @@ def run(parser: ArgumentParser, args: Namespace, remaining: list[str]) -> int:
 
     pattern = re.compile(args.filter_regex) if args.filter_regex else None
 
+    feditest.load_default_tests()
     feditest.load_tests_from(args.testsdir)
 
     test_plan_specs : list[TestPlanTestSpec]= []

--- a/src/feditest/cli/commands/create_testplan.py
+++ b/src/feditest/cli/commands/create_testplan.py
@@ -15,6 +15,7 @@ def run(parser: ArgumentParser, args: Namespace, remaining: list[str]) -> int:
         parser.print_help()
         return 0
 
+    feditest.load_default_tests()
     feditest.load_tests_from(args.testsdir)
 
     constellations = []

--- a/src/feditest/cli/commands/info.py
+++ b/src/feditest/cli/commands/info.py
@@ -18,10 +18,12 @@ def run(parser: ArgumentParser, args: Namespace, remaining: list[str]) -> int:
         parser.print_help()
         return 0
 
+    feditest.load_default_tests()
     feditest.load_tests_from(args.testsdir)
+
+    feditest.load_default_node_drivers()
     if args.nodedriversdir:
         feditest.load_node_drivers_from(args.nodedriversdir)
-    feditest.load_default_node_drivers()
 
     if args.test:
         return run_info_test(args.test)

--- a/src/feditest/cli/commands/list_tests.py
+++ b/src/feditest/cli/commands/list_tests.py
@@ -17,7 +17,9 @@ def run(parser: ArgumentParser, args: Namespace, remaining: list[str]) -> int:
 
     pattern = re.compile(args.filter_regex) if args.filter_regex else None
 
+    feditest.load_default_tests()
     feditest.load_tests_from(args.testsdir)
+
     for name in sorted(feditest.all_tests.keys()):
         if pattern is None or pattern.match(name):
             print(name)

--- a/src/feditest/cli/commands/run.py
+++ b/src/feditest/cli/commands/run.py
@@ -30,10 +30,12 @@ def run(parser: ArgumentParser, args: Namespace, remaining: list[str]) -> int:
         parser.print_help()
         return 0
 
+    feditest.load_default_tests()
     feditest.load_tests_from(args.testsdir)
+
+    feditest.load_default_node_drivers()
     if args.nodedriversdir:
         feditest.load_node_drivers_from(args.nodedriversdir)
-    feditest.load_default_node_drivers()
 
     if args.domain:
         feditest.registry = Registry.create(args.domain) # overwrite


### PR DESCRIPTION
Load default NodeDrivers and default tests first, so local setup can override them